### PR TITLE
Actualizacion del tamaño minimo de la contraseña

### DIFF
--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -54,6 +54,16 @@ export default function PasswordResetForm() {
       return;
     }
 
+    if (formState.password.length < 8) {
+      setFormState((prev) => ({
+        ...prev,
+        isLoading: false,
+        message: "La contraseña debe tener al menos 8 caracteres",
+        isError: true,
+      }));
+      return;
+    }
+
     setFormState((prev) => ({
       ...prev,
       isLoading: true,


### PR DESCRIPTION
Agregue una validacion en la pantalla de reestablecer contraseña para que muestre un mensaje de error en caso de que el tamaño de la contraseña es menor a 8 caracteres