### PR TITLE
filtro por productos en el movimiento

### DIFF
--- a/src/components/admin/movements/MovementFilters.tsx
+++ b/src/components/admin/movements/MovementFilters.tsx
@@ -41,11 +41,20 @@ export default function MovementFilters({ token, filters, setFilters }: Props) {
   return (
     <div className="mb-6 space-y-4">
       <div className="flex flex-col md:flex-row items-center gap-4">
-        <div className="w-full">
+        <div className="w-full md:w-1/2">
           <SearchBar
             placeholder="Ingrese el RUC del encargado"
             defaultQuery={filters.managerRuc ?? ""}
             onSearch={(value) => handleChange("managerRuc", value)}
+            debounceDelay={300}
+          />
+        </div>
+
+        <div className="w-full md:w-1/2">
+          <SearchBar
+            placeholder="Buscar por nombre de producto"
+            defaultQuery={filters.productName ?? ""}
+            onSearch={(value) => handleChange("productName", value)}
             debounceDelay={300}
           />
         </div>

--- a/src/lib/movements/IMovements.ts
+++ b/src/lib/movements/IMovements.ts
@@ -6,6 +6,7 @@ import { BaseQueryParams } from "../types";
     originStockId?: number;
     destinationStockId?: number;
     managerId?: number;
+    productName?: string;
   }
 
   export interface MovementData {


### PR DESCRIPTION
filtra movimientos por producto. Se implementó con el buscador genérico, se escribe el nombre del producto y la lista de movimientos se filtra en base a los que contienen ese producto