### PR TITLE
Task 358 fe fetch util/hook

### DIFF
--- a/src/components/admin/provider/ProviderDetail.tsx
+++ b/src/components/admin/provider/ProviderDetail.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from "react";
-import { Phone, Building2 } from "lucide-react";
+import React from "react";
+import { Phone, Building2, Loader2 } from "lucide-react";
 import { Provider } from "@/lib/provider/IProvider";
-import { getProviderById } from "@/lib/provider/getProviderById";
+import { PROVIDER_API } from "@/lib/urls";
+import { useFetch } from "@/hooks/api"; // Importamos nuestro nuevo hook
 
 interface ProviderDetailProps {
   token: string;
@@ -9,32 +10,21 @@ interface ProviderDetailProps {
 }
 
 export const ProviderDetail: React.FC<ProviderDetailProps> = ({ token, providerId }) => {
-  const [provider, setProvider] = useState<Provider | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    const fetchProviderDetails = async () => {
-      if (providerId) {
-        setIsLoading(true);
-        try {
-          const fetchedProvider = await getProviderById(providerId, token);
-          setProvider(fetchedProvider);
-        } catch (error) {
-          console.error("Error fetching provider details:", error);
-        } finally {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchProviderDetails();
-  }, [providerId, token]);
+  // Utilizamos nuestro hook para obtener los datos del proveedor
+  const { data: provider, loading: isLoading, error } = useFetch<Provider>(
+    `${PROVIDER_API}/${providerId}`,
+    token,
+    { immediate: true } // Realizar la petición inmediatamente
+  );
 
   return (
     <div className="space-y-4">
       <div className="text-center">
         {isLoading ? (
-          <h2 className="text-sm text-gray-600 mt-4">Cargando detalles del proveedor...</h2>
+          <div className="flex items-center justify-center gap-2 mt-4">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <h2 className="text-sm text-gray-600">Cargando detalles del proveedor...</h2>
+          </div>
         ) : (
           <h2 className="text-xl font-bold mt-4">
             {provider?.businessName || "Detalles del Proveedor"}
@@ -44,7 +34,13 @@ export const ProviderDetail: React.FC<ProviderDetailProps> = ({ token, providerI
 
       <div className="border-t border-gray-300 mt-1 w-full"></div>
 
-      {!isLoading && provider ? (
+      {error && (
+        <div className="text-center text-red-500 mt-4">
+          Error al cargar los detalles del proveedor: {error.message}
+        </div>
+      )}
+
+      {!isLoading && !error && provider ? (
         <div className="space-y-4">
           <div className="pl-2">
             <p className="text-sm text-gray-600">Descripción:</p>
@@ -72,7 +68,11 @@ export const ProviderDetail: React.FC<ProviderDetailProps> = ({ token, providerI
           </div>
         </div>
       ) : (
-        !isLoading && <div className="text-center text-red-500 mt-4">No se pudieron cargar los detalles del proveedor</div>
+        !isLoading && !error && (
+          <div className="text-center text-amber-500 mt-4">
+            No se encontró información del proveedor
+          </div>
+        )
       )}
     </div>
   );

--- a/src/components/admin/settings/tags/TagList.tsx
+++ b/src/components/admin/settings/tags/TagList.tsx
@@ -7,7 +7,6 @@ import TagTable from "./TagTable";
 import { toast } from "@/lib/toast";
 import TagForm from "./TagForm";
 import { Tag } from "@/lib/tags/types";
-import { useDelTag } from "@/hooks/tags/useDelTag";
 import { ConfirmationModal } from "@/components/global/Confirmation-modal";
 import { useTagForm } from "@/hooks/tags/useTagForm";
 import { usePaginatedFetch } from "@/hooks/api/usePaginatedFetch";

--- a/src/components/admin/settings/tags/TagList.tsx
+++ b/src/components/admin/settings/tags/TagList.tsx
@@ -2,7 +2,6 @@
 
 import SearchBar from "@/components/global/SearchBar";
 import { Button } from "@/components/ui/button";
-import { useGetTags } from "@/hooks/tags/useGetTags";
 import React, { useState } from "react";
 import TagTable from "./TagTable";
 import { toast } from "@/lib/toast";
@@ -11,6 +10,9 @@ import { Tag } from "@/lib/tags/types";
 import { useDelTag } from "@/hooks/tags/useDelTag";
 import { ConfirmationModal } from "@/components/global/Confirmation-modal";
 import { useTagForm } from "@/hooks/tags/useTagForm";
+import { usePaginatedFetch } from "@/hooks/api/usePaginatedFetch";
+import { TAG_API } from "@/lib/urls";
+import { useFetch } from "@/hooks/api";
 
 type TagListProps = {
   token: string;
@@ -20,20 +22,34 @@ const TagList = ({ token }: TagListProps) => {
   const [isDelOpen, setIsDelOpen] = useState(false);
   const { selectedTag, isFormOpen, setSelectedTag, onCreate, onEdit, onClose } =
     useTagForm();
-  const { data, isLoading, error, query, setQuery, setData, onPageChange } =
-    useGetTags({
-      token,
-    });
-  const {
-    delTag,
-    error: delError,
-    isLoading: isDelLoading,
-  } = useDelTag({ token });
 
-  if (error) toast("error", error);
+  const {
+    data,
+    loading: isLoading,
+    error,
+    pagination = { currentPage: 1, totalPages: 1, totalItems: 0, pageSize: 10 },
+    setPage,
+    refresh,
+    search,
+  } = usePaginatedFetch<Tag>(TAG_API, token, {
+    initialPage: 1,
+    size: 10,
+    autoFetch: true,
+  });
+
+  const { delete: deleteTag, loading: isDelLoading } = useFetch<void, null>(
+    "",
+    token
+  );
+
+  if (error) toast("error", error.message || "Error al cargar las etiquetas");
 
   const handleSearch = (query: string) => {
-    setQuery({ page: 1, name: query.length > 0 ? query : undefined });
+    if (query.length > 0) {
+      search({ name: query });
+    } else {
+      refresh();
+    }
   };
 
   // Delete logic
@@ -46,42 +62,27 @@ const TagList = ({ token }: TagListProps) => {
 
   const handleDelete = async () => {
     if (!selectedTag) return;
-    await delTag(selectedTag.id);
-    if (delError) toast("error", delError);
-    else {
-      setData((prev) => {
-        if (!prev) return null;
-        return {
-          ...prev,
-          data: prev.data.filter((tag) => tag.id !== selectedTag.id),
-        };
-      });
-      toast("success", "Etiqueta eliminada con éxito");
+
+    const { ok, error } = await deleteTag(null, `${TAG_API}/${selectedTag.id}`);
+
+    if (!ok) {
+      return toast("error", error?.message || "Error al eliminar la etiqueta");
     }
+
+    toast("success", "Etiqueta eliminada con éxito");
+    refresh();
+    onCloseDelModal();
   };
 
-  // Create / Update logic
-  const handleSubmit = (tag: Tag) => {
-    const isEdit = selectedTag && selectedTag.id === tag.id;
-    setData((prev) => {
-      if (!prev) return null;
-      if (isEdit)
-        return {
-          ...prev,
-          data: prev.data.map((t) => (t.id === tag.id ? tag : t)),
-        };
-      return { ...prev, data: [tag, ...prev.data] };
-    });
+  const handleSubmit = () => {
+    refresh();
   };
 
   return (
     <>
       <div className="p-4 mx-auto">
         <div className="flex items-center gap-4 mb-4">
-          <SearchBar 
-            onSearch={handleSearch} 
-            placeholder="Buscar tag..." 
-          />
+          <SearchBar onSearch={handleSearch} placeholder="Buscar tag..." />
         </div>
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-3xl font-bold">Tags</h2>
@@ -91,17 +92,17 @@ const TagList = ({ token }: TagListProps) => {
         </div>
         <TagTable
           emptyMessage="No se encontraron tags"
-          onPageChange={onPageChange}
+          onPageChange={setPage}
           handleEdit={onEdit}
           handleDel={onOpenDelModal}
           token={token}
           isLoading={isLoading}
-          data={data?.data || []}
+          data={data || []}
           pagination={{
-            currentPage: query.page,
-            totalPages: data?.totalPages || 1,
-            totalItems: data?.total || 0,
-            pageSize: data?.size || 10,
+            currentPage: pagination?.currentPage || 1,
+            totalPages: pagination?.totalPages || 1,
+            totalItems: pagination?.totalItems || 0,
+            pageSize: pagination?.pageSize || 10,
           }}
         />
       </div>

--- a/src/hooks/api/index.ts
+++ b/src/hooks/api/index.ts
@@ -1,0 +1,2 @@
+export * from './useFetch';
+export * from './usePaginatedFetch';

--- a/src/hooks/api/useFetch.ts
+++ b/src/hooks/api/useFetch.ts
@@ -1,0 +1,91 @@
+import { useState, useCallback } from 'react';
+import { apiFetch, ApiError, ApiMethod, ApiOptions } from '@/lib/api/apiFetch';
+
+interface UseFetchState<T> {
+  data: T | null;
+  error: ApiError | null;
+  loading: boolean;
+}
+
+interface UseFetchOptions extends Omit<ApiOptions, 'body'> {
+  immediate?: boolean; // Si es true, realiza la petición inmediatamente
+}
+
+/**
+ * Hook para realizar peticiones HTTP con gestión de estado
+ * @param url URL de la petición
+ * @param token Token de autenticación
+ * @param options Opciones adicionales
+ * @returns Estado de la petición y función para ejecutarla
+ */
+export function useFetch<T = unknown, P = unknown>(
+  url: string,
+  token?: string | null,
+  options: UseFetchOptions = {}
+) {
+  const { immediate = false, ...fetchOptions } = options;
+  const [state, setState] = useState<UseFetchState<T>>({
+    data: null,
+    error: null,
+    loading: immediate,
+  });
+
+  const execute = useCallback(
+    async (
+      body?: P,
+      dynamicUrl: string = url,
+      dynamicMethod?: ApiMethod
+    ) => {
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+
+      try {
+        const method = dynamicMethod || options.method;
+        const response = await apiFetch<T>(
+          dynamicUrl,
+          token,
+          {
+            ...fetchOptions,
+            method,
+            body,
+            throwErrors: false,
+          }
+        );
+
+        setState({
+          data: response.data,
+          error: response.error,
+          loading: false,
+        });
+
+        return response;
+      } catch (error) {
+        const apiError = error as ApiError;
+        setState({
+          data: null,
+          error: apiError,
+          loading: false,
+        });
+        return { data: null, error: apiError, ok: false, status: apiError.status || 0 };
+      }
+    },
+    [url, token, options.method, fetchOptions]
+  );
+
+  // Si immediate es true, ejecutar la petición inmediatamente
+  useState(() => {
+    if (immediate) {
+      execute();
+    }
+  });
+
+  return {
+    ...state,
+    execute,
+    // Métodos auxiliares para diferentes tipos de peticiones
+    get: useCallback((params?: P, dynamicUrl?: string) => execute(params, dynamicUrl, 'GET'), [execute]),
+    post: useCallback((body?: P, dynamicUrl?: string) => execute(body, dynamicUrl, 'POST'), [execute]),
+    put: useCallback((body?: P, dynamicUrl?: string) => execute(body, dynamicUrl, 'PUT'), [execute]),
+    patch: useCallback((body?: P, dynamicUrl?: string) => execute(body, dynamicUrl, 'PATCH'), [execute]),
+    delete: useCallback((params?: P, dynamicUrl?: string) => execute(params, dynamicUrl, 'DELETE'), [execute]),
+  };
+}

--- a/src/hooks/api/usePaginatedFetch.ts
+++ b/src/hooks/api/usePaginatedFetch.ts
@@ -1,0 +1,142 @@
+import { useState, useEffect, useCallback } from "react";
+import { fetchPaginated, ApiPaginationOptions } from "@/lib/api/apiPagination";
+import { ApiError } from "@/lib/api/apiFetch";
+
+interface UsePaginatedFetchState<T> {
+  data: T[];
+  loading: boolean;
+  error: ApiError | null;
+  pagination: {
+    currentPage: number;
+    totalPages: number;
+    totalItems: number;
+    pageSize: number;
+  };
+}
+
+interface UsePaginatedFetchOptions extends Omit<ApiPaginationOptions, "page"> {
+  initialPage?: number;
+  autoFetch?: boolean;
+}
+
+/**
+ * Hook para realizar peticiones paginadas con gestión de estado
+ * @param baseUrl URL base de la API
+ * @param token Token de autenticación
+ * @param options Opciones de configuración
+ * @returns Estado y funciones para manejar la paginación
+ */
+export function usePaginatedFetch<T = unknown>(
+  baseUrl: string,
+  token: string,
+  options: UsePaginatedFetchOptions = {}
+) {
+  const { initialPage = 1, autoFetch = true, ...fetchOptions } = options;
+
+  const [state, setState] = useState<UsePaginatedFetchState<T>>({
+    data: [],
+    loading: autoFetch,
+    error: null,
+    pagination: {
+      currentPage: initialPage,
+      totalPages: 1,
+      totalItems: 0,
+      pageSize: fetchOptions.size || 10,
+    },
+  });
+
+  const fetchData = useCallback(
+    async (
+      page: number = state.pagination.currentPage,
+      extraParams?: Record<string, unknown>
+    ) => {
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+
+      try {
+        const mergedParams = {
+          ...fetchOptions.extraParams,
+          ...extraParams,
+        };
+
+        const response = await fetchPaginated<T>(baseUrl, token, {
+          ...fetchOptions,
+          page,
+          extraParams: mergedParams as Record<
+            string,
+            string | number | boolean | undefined
+          >,
+        });
+
+        setState({
+          data: response.data,
+          loading: false,
+          error: null,
+          pagination: {
+            currentPage: response.currentPage,
+            totalPages: response.totalPages,
+            totalItems: response.total,
+            pageSize: response.size,
+          },
+        });
+
+        return response;
+      } catch (error) {
+        const apiError = error as ApiError;
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: apiError,
+        }));
+        return null;
+      }
+    },
+    [baseUrl, token, fetchOptions, state.pagination.currentPage]
+  );
+
+  const setPage = useCallback(
+    (page: number) => {
+      if (page < 1) page = 1;
+      if (
+        state.pagination.totalPages > 0 &&
+        page > state.pagination.totalPages
+      ) {
+        page = state.pagination.totalPages;
+      }
+
+      setState((prev) => ({
+        ...prev,
+        pagination: {
+          ...prev.pagination,
+          currentPage: page,
+        },
+      }));
+
+      return fetchData(page);
+    },
+    [fetchData, state.pagination.totalPages]
+  );
+
+  const search = useCallback(
+    (params: Record<string, unknown>) => {
+      return fetchData(1, params);
+    },
+    [fetchData]
+  );
+
+  // Cargar datos automáticamente si autoFetch es true
+  useEffect(() => {
+    if (autoFetch && token) {
+      fetchData(initialPage);
+    }
+  }, [autoFetch, initialPage]);
+
+  return {
+    ...state,
+    fetchData,
+    setPage,
+    search,
+    nextPage: () => setPage(state.pagination.currentPage + 1),
+    prevPage: () => setPage(state.pagination.currentPage - 1),
+    refresh: () => fetchData(state.pagination.currentPage),
+  };
+}

--- a/src/lib/api/apiFetch.ts
+++ b/src/lib/api/apiFetch.ts
@@ -1,0 +1,155 @@
+import { toast } from "../toast";
+
+export type ApiMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface ApiError extends Error {
+  status?: number;
+  data?: unknown;
+}
+
+export interface ApiOptions {
+  method?: ApiMethod;
+  headers?: Record<string, string>;
+  body?: unknown;
+  throwErrors?: boolean; // Si es falso, maneja los errores internamente
+  showToast?: boolean; // Si es true, muestra mensajes toast en caso de error
+  customErrorMessage?: string;
+}
+
+export interface ApiResponse<T> {
+  data: T | null;
+  error: ApiError | null;
+  status: number;
+  ok: boolean;
+}
+
+/**
+ * Función utilitaria para realizar peticiones a la API
+ * @param url URL a la que se realiza la petición
+ * @param token Token de autenticación (opcional)
+ * @param options Opciones adicionales para la petición
+ * @returns Respuesta tipada según el genérico proporcionado
+ */
+export async function apiFetch<T>(
+  url: string,
+  token?: string | null,
+  options: ApiOptions = {}
+): Promise<ApiResponse<T>> {
+
+  const {
+    method = "GET",
+    headers: customHeaders = {},
+    body,
+    throwErrors = true,
+    showToast = true,
+    customErrorMessage,
+  } = options;
+
+  // Configurar headers con autenticación si se proporciona un token
+  const headers: Record<string, string> = {
+    ...customHeaders,
+  };
+
+  // Check if token is truly available and valid
+  if (token && typeof token === 'string' && token.trim() !== '') {
+    headers["Authorization"] = `Bearer ${token}`;
+  } else {
+    console.log("No valid token provided to apiFetch");
+  }
+
+  // Si el body no es FormData, establecer el Content-Type a JSON
+  if (body && !(body instanceof FormData)) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  try {
+    // Configurar opciones del fetch
+    const fetchOptions: RequestInit = {
+      method,
+      headers,
+    };
+
+    // Añadir body si es necesario
+    if (body) {
+      if (body instanceof FormData) {
+        fetchOptions.body = body;
+      } else {
+        fetchOptions.body = JSON.stringify(body);
+      }
+    }
+
+    const response = await fetch(url, fetchOptions);
+    
+    const isJsonResponse = 
+      response.headers.get("content-type")?.includes("application/json");
+
+    // Procesar la respuesta según su tipo
+    let data = null;
+    
+    if (isJsonResponse) {
+      try {
+        data = await response.json();
+      } catch (err) {
+        console.error("Error parsing JSON response:", err);
+      }
+    }
+
+    // Si la respuesta no es exitosa, manejar el error
+    if (!response.ok) {
+      const error: ApiError = new Error(
+        customErrorMessage || 
+        (data && typeof data === "object" && "message" in data 
+          ? data.message 
+          : `Error ${response.status}: ${response.statusText}`)
+      );
+      
+      error.status = response.status;
+      error.data = data;
+
+      if (showToast) {
+        toast(
+          "error",
+          customErrorMessage || 
+          (data && typeof data === "object" && "message" in data 
+            ? data.message 
+            : `Error en la petición`)
+        );
+      }
+
+      if (throwErrors) {
+        throw error;
+      }
+
+      return { 
+        data: null, 
+        error, 
+        status: response.status, 
+        ok: false 
+      };
+    }
+
+    return { 
+      data: data as T, 
+      error: null, 
+      status: response.status, 
+      ok: true 
+    };
+  } catch (err) {
+    const error = err as ApiError;
+    
+    if (showToast && !error.status) { // Evita mostrar dos toast si ya se mostró uno
+      toast("error", customErrorMessage || "Error de conexión");
+    }
+    
+    if (throwErrors) {
+      throw error;
+    }
+    
+    return {
+      data: null,
+      error,
+      status: error.status || 0,
+      ok: false
+    };
+  }
+}

--- a/src/lib/api/apiPagination.ts
+++ b/src/lib/api/apiPagination.ts
@@ -1,0 +1,63 @@
+import { PaginationResponse } from "../types";
+import { apiFetch, ApiOptions } from "./apiFetch";
+
+// Opciones específicas para peticiones paginadas
+export interface ApiPaginationOptions extends Omit<ApiOptions, 'method'> {
+  page?: number;
+  size?: number;
+  extraParams?: Record<string, string | number | boolean | undefined>;
+}
+
+/**
+ * Realiza una petición paginada y devuelve los resultados con su información de paginación
+ * @param baseUrl URL base de la API
+ * @param token Token de autenticación
+ * @param options Opciones de la petición
+ * @returns Respuesta paginada tipada
+ */
+export async function fetchPaginated<T =unknown>(
+  baseUrl: string,
+  token: string,
+  options: ApiPaginationOptions = {}
+): Promise<PaginationResponse<T>> {
+
+  const { page = 1, size, extraParams = {}, ...apiOptions } = options;
+  // Construir los parámetros de query
+  const queryParams = new URLSearchParams();
+  queryParams.append("page", page.toString());
+  
+  if (size) {
+    queryParams.append("size", size.toString());
+  }
+  
+  // Añadir parámetros adicionales
+  Object.entries(extraParams).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      queryParams.append(key, String(value));
+    }
+  });
+  
+  // Construir la URL completa
+  const url = `${baseUrl}?${queryParams.toString()}`;
+  
+  // Realizar la petición
+  const response = await apiFetch<PaginationResponse<T>>(url, token, {
+    method: "GET",
+    ...apiOptions,
+  });
+  
+  // Si hay un error, devolver una respuesta paginada vacía
+  if (!response.ok || !response.data) {
+    return {
+      data: [] as T[],
+      total: 0,
+      size: size || 10,
+      prev: false,
+      next: false,
+      currentPage: page,
+      totalPages: 0,
+    };
+  }
+  
+  return response.data;
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,6 @@
+export * from './apiFetch';
+
+// También podrías añadir aquí otras exportaciones a medida que se creen más utilidades API
+// Por ejemplo:
+// export * from './apiCache'; 
+// export * from './apiMock';

--- a/src/lib/api/services/index.ts
+++ b/src/lib/api/services/index.ts
@@ -1,0 +1,7 @@
+export * from './providerService';
+
+// A medida que se creen más servicios, se pueden exportar desde aquí
+// Por ejemplo:
+// export * from './petService';
+// export * from './userService';
+// etc.

--- a/src/lib/api/services/providerService.ts
+++ b/src/lib/api/services/providerService.ts
@@ -1,0 +1,74 @@
+import { apiFetch } from '../apiFetch';
+import { fetchPaginated } from '../apiPagination';
+import { PROVIDER_API } from '@/lib/urls';
+import { Provider, ProviderQueryParams } from '@/lib/provider/IProvider';
+import { PaginationResponse } from '@/lib/types';
+
+/**
+ * Obtiene un listado paginado de proveedores
+ */
+export async function getProviders(
+  token: string,
+  params: ProviderQueryParams
+): Promise<PaginationResponse<Provider>> {
+  return fetchPaginated<Provider>(PROVIDER_API, token, {
+    extraParams: params,
+  });
+}
+
+/**
+ * Obtiene un proveedor por su ID
+ */
+export async function getProviderById(
+  providerId: number,
+  token: string
+): Promise<Provider | null> {
+  const response = await apiFetch<Provider>(`${PROVIDER_API}/${providerId}`, token);
+  
+  return response.data;
+}
+
+/**
+ * Crea un nuevo proveedor
+ */
+export async function createProvider(
+  token: string,
+  data: Provider
+) {
+  const response = await apiFetch<Provider>(PROVIDER_API, token, {
+    method: 'POST',
+    body: data,
+  });
+  
+  return response.data;
+}
+
+/**
+ * Actualiza un proveedor existente
+ */
+export async function updateProvider(
+  token: string,
+  id: number,
+  data: Provider
+) {
+  const response = await apiFetch<Provider>(`${PROVIDER_API}/${id}`, token, {
+    method: 'PATCH',
+    body: data,
+  });
+  
+  return response.data;
+}
+
+/**
+ * Elimina un proveedor
+ */
+export async function deleteProvider(
+  token: string,
+  id: number
+) {
+  const response = await apiFetch(`${PROVIDER_API}/${id}`, token, {
+    method: 'DELETE',
+  });
+  
+  return response.ok;
+}


### PR DESCRIPTION
📌 Descripción de la PR
Se integraron los hooks personalizados useFetch y usePaginatedFetch en la página de Tags para demostrar cómo se pueden utilizar en un CRUD real.
Esto permite una mayor reutilización de lógica para operaciones HTTP (GET, DELETE, etc.) y mejora la organización del código.

✅ Cambios realizados
Se implementó usePaginatedFetch para cargar y paginar los tags desde el endpoint correspondiente.

Se reemplazó el hook específico useDelTag por el más genérico useFetch, utilizando su método delete para la eliminación de tags.

Se mantuvo la lógica del modal de confirmación (ConfirmationModal) para una experiencia de usuario clara y segura al eliminar.

Se ajustó handleDelete para trabajar con useFetch, incluyendo manejo de errores, cierre del modal y actualización de la lista.

🎯 Objetivo
Mostrar una implementación práctica de los hooks useFetch y usePaginatedFetch en un módulo CRUD (Tags), facilitando su reutilización en otras secciones de la app que requieran operaciones similares.

🧪 Cómo probar
Acceder a la página de Tags.

Probar la búsqueda de tags con la barra superior.

Crear, editar y eliminar tags.

Al eliminar:

Confirmar que el modal funciona correctamente.

Se muestre un toast de éxito o error.

La lista se actualice automáticamente.

