### PR TITLE
cambio en genero

### DIFF
--- a/src/components/pet/PetDetails.tsx
+++ b/src/components/pet/PetDetails.tsx
@@ -128,7 +128,12 @@ export default function PetDetails({ token }: Props) {
         },
         {
           label: "Género",
-          value: pet.sex || "No especificado",
+          value:
+            pet.sex === "F"
+              ? "Hembra"
+              : pet.sex === "M"
+              ? "Macho"
+              : "No especificado",
           icon: <CircleDot className="h-4 w-4" />,
         },
       ]


### PR DESCRIPTION
Se actualizó la visualización del género de la mascota. Ahora, si el valor recibido es "F", se muestra como "Hembra" y si es "M", se muestra como "Macho".