### PR TITLE
[424] Deshacer especies eliminadas

### DIFF
--- a/src/app/dashboard/settings/species/page.tsx
+++ b/src/app/dashboard/settings/species/page.tsx
@@ -13,7 +13,7 @@ export default async function SpeciesPage() {
     const token = session?.user?.token || null;
 
     return (
-        <div className="flex flex-col justify-between items-center gap-4 p-6">
+        <div>
             <SpeciesList token={token} />
         </div>
     );

--- a/src/components/admin/settings/species/SpeciesList.tsx
+++ b/src/components/admin/settings/species/SpeciesList.tsx
@@ -6,20 +6,20 @@ import { Species } from "@/lib/pets/IPet";
 import { getAllSpecies } from "@/lib/pets/getRacesAndSpecies";
 import {deleteSpeciesById} from "@/lib/pets/species/deleteSpecieById";
 import SearchBar from "@/components/global/SearchBar";
-import { Pencil, Trash } from "lucide-react";
+import { Pencil, Trash, Undo2} from "lucide-react";
 import { toast } from "@/lib/toast";
 import GenericTable, { Column, TableAction, PaginationInfo } from "@/components/global/GenericTable";
 import { ConfirmationModal } from "@/components/global/Confirmation-modal";
-import { useRouter } from "next/navigation";
 import SpeciesTableSkeleton from "./skeleton/SpecieTableSkeleton";
 import SpeciesFormModal from "./SpeciesFormModal";
+import { useFetch } from "@/hooks/api";
+import { SPECIES_API } from "@/lib/urls";
 
 interface SpeciesListProps {
     token: string | null;
 }
 
 export default function SpeciesList({ token }: SpeciesListProps) {
-    const router = useRouter();
     const [speciesList, setSpeciesList] = useState<Species[]>([]);
     const [pagination, setPagination] = useState<PaginationInfo>({
         currentPage: 1, totalPages: 1, totalItems: 0, pageSize: 10,
@@ -30,9 +30,10 @@ export default function SpeciesList({ token }: SpeciesListProps) {
     const [isFormOpen, setIsFormOpen] = useState(false);
     const [speciesToEdit, setSpeciesToEdit] = useState<Species | null>(null);
     const [searchQuery, setSearchQuery] = useState<string>("");
+    const [showDeleted, setShowDeleted] = useState(false);
+    const [isRestoring, setIsRestoring] = useState(false);
 
-
-    const loadSpecies = useCallback(async (page = 1, query = "") => {
+    const loadSpecies = useCallback(async (page = 1, query = "", includeDeleted = showDeleted) => {
         if (!token) return;
         setLoading(true);
         try {
@@ -41,6 +42,7 @@ export default function SpeciesList({ token }: SpeciesListProps) {
             if(query.trim() !== "") {
                 params.append("name", query.trim());
             }
+            params.append("includeDeleted",  includeDeleted.toString())
             
             const response = await getAllSpecies(token, params.toString());
 
@@ -59,6 +61,10 @@ export default function SpeciesList({ token }: SpeciesListProps) {
         }
     }, [token]);
 
+    const { patch: restoreSpecie} = useFetch<Species, null>(
+       "",
+        token
+    );
     useEffect(() => {
         if (token) loadSpecies(pagination.currentPage);
     }, [token, pagination.currentPage, loadSpecies]);
@@ -85,24 +91,57 @@ export default function SpeciesList({ token }: SpeciesListProps) {
 
     const handleSearch = (query: string) => {
         setSearchQuery(query);
-        loadSpecies(1, query);
+        const newShowDeleted = showDeleted; //obtenemos el valor más actual de showDeleted
+        loadSpecies(1, query, newShowDeleted);
     }
     const handlePageChange = (page: number) => {
         loadSpecies(page, searchQuery);
     };
+    const handleRestore = async (specie: Species) => {
+        setIsRestoring(true)
+        const { ok, error } = await restoreSpecie(null, `${SPECIES_API}/restore/${specie.id}`);
+
+        if (!ok) {
+            return toast("error", error?.message || "Error al restaurar la especie");
+        }
+
+        toast("success", "Especie restaurada con éxito");
+        loadSpecies(pagination.currentPage, searchQuery, showDeleted);
+        setIsRestoring(false);
+    };
+
+    const toggleDeletedSpecies =  () => {
+        setIsRestoring(false)
+        setShowDeleted(!showDeleted)
+        loadSpecies(1, searchQuery, !showDeleted)
+    }
 
     const columns: Column<Species>[] = [{ header: "Nombre", accessor: "name" }];
 
     const actions: TableAction<Species>[] = [
-        { icon: <Pencil className="w-4 h-4" />, onClick: (s) => {
+    ...(showDeleted
+      ? [
+          {
+            icon: <Undo2 className={`w-4 h-4 ${isRestoring ? 'opacity-50' : ''}`} />,
+            label: isRestoring ? "Restaurando..." : "Restaurar",
+            onClick: (specie: Species) => {
+              if (!isRestoring) {
+                handleRestore(specie);
+              }
+            },
+          },
+        ]
+      : [
+        { icon: <Pencil className="w-4 h-4" />, onClick: (s: Species) => {
             setSpeciesToEdit(s);
             setIsFormOpen(true);
         }, label: "Editar" },
         { icon: <Trash className="w-4 h-4" />, onClick: confirmDelete, label: "Eliminar" },
+        ]),
     ];
 
     return (
-        <div className="w-4/5 mx-auto px-4 py-6">
+        <div className="mx-auto p-4">
             <div className="flex items-center gap-4 mb-4">
                 <SearchBar 
                     onSearch={handleSearch} 
@@ -111,12 +150,21 @@ export default function SpeciesList({ token }: SpeciesListProps) {
             </div>
 
             <div className="flex justify-between items-center mb-4">
-                <h2 className="text-3xl font-bold">Especies</h2>
-                <Button variant="outline" className="px-6" onClick={() => {
-                    setSpeciesToEdit(null);
-                    setIsFormOpen(true);}}>
-                    Agregar
-                </Button>
+                <h2 className="text-3xl font-bold">{showDeleted ? "Especies eliminadas" : "Especies"}</h2>
+                <div className="flex gap-2">
+                    <Button 
+                        variant={showDeleted ? "secondary" : "outline"}
+                        onClick={toggleDeletedSpecies}
+                        disabled={isRestoring}
+                    >
+                        {showDeleted ? "Ver activos" : "Ver eliminados"}
+                    </Button>
+                    <Button variant="default" className="px-6" disabled={isRestoring} onClick={() => {
+                        setSpeciesToEdit(null);
+                        setIsFormOpen(true);}}>
+                        Agregar
+                    </Button>
+                </div>
             </div>
 
             <GenericTable

--- a/src/components/admin/settings/species/skeleton/SpecieTableSkeleton.tsx
+++ b/src/components/admin/settings/species/skeleton/SpecieTableSkeleton.tsx
@@ -2,12 +2,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function SpeciesTableSkeleton() {
     return (
-        <div className="space-y-2">
-            {[...Array(10)].map((_, i) => (
+        <div className="space-y-5">
+            {[...Array(5)].map((_, i) => (
                 <div key={i} className="flex items-center gap-4">
-                    <Skeleton className="h-4 w-1/4" /> {/* Nombre */}
-                    <Skeleton className="h-4 w-1/2" /> {/* Descripción */}
-                    <Skeleton className="h-4 w-16 ml-auto" /> {/* Acciones */}
+                    <Skeleton className="h-6 w-1/4" /> {/* Nombre */}
+                    <Skeleton className="h-6 w-16 ml-auto" /> {/* Acciones */}
                 </div>
             ))}
         </div>

--- a/src/components/admin/settings/tags/TagList.tsx
+++ b/src/components/admin/settings/tags/TagList.tsx
@@ -20,6 +20,7 @@ type TagListProps = {
 const TagList = ({ token }: TagListProps) => {
   const [isDelOpen, setIsDelOpen] = useState(false);
   const [showDeleted, setShowDeleted] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const { selectedTag, isFormOpen, setSelectedTag, onCreate, onEdit, onClose } =
     useTagForm();
 
@@ -53,6 +54,7 @@ const TagList = ({ token }: TagListProps) => {
   if (error) toast("error", error.message || "Error al cargar las etiquetas");
 
   const handleSearch = (query: string) => {
+    setSearchQuery(query)
     if (query.length > 0) {
       search({ name: query, includeDeleted: showDeleted });
     } else {
@@ -62,7 +64,7 @@ const TagList = ({ token }: TagListProps) => {
 
   const toggleDeletedTags = () => {
     setShowDeleted(!showDeleted);
-    search({ includeDeleted: !showDeleted });
+    search( {name: searchQuery, includeDeleted: !showDeleted })
   };
 
   const handleRestore = async (tag: Tag) => {


### PR DESCRIPTION
Se añadió un botón que filtra las especies por aquellas que fueron eliminadas, donde también aparecerán con botones que realizan la restauración de la especie seleccionada

Se cambió también el estilo del skeleton y se corrigió un bug del taglist