### PR TITLE
[526] Limitar filtros de fechas

### DIFF
--- a/src/components/admin/appointment/filters/AppointmentDateFilter.tsx
+++ b/src/components/admin/appointment/filters/AppointmentDateFilter.tsx
@@ -70,12 +70,23 @@ export default function AppointmentDateFilter({ filters, setFilters }: Props) {
           className={clsx(
             "w-full border px-3 py-2 rounded",
           )}
-          value={startDate}
+          min="1900-01-01"
+          max={(() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })()}
+          value={startDate || ""}
           onChange={(e) => {
             const value = e.target.value;
             setStartDate(value);
             if (endDate && value > endDate) {
               setEndDate("");
+            }
+          }}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = (() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })();
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setStartDate(value);
             }
           }}
         />
@@ -90,9 +101,19 @@ export default function AppointmentDateFilter({ filters, setFilters }: Props) {
             "w-full border px-3 py-2 rounded",
             endDateError && "border-red-500"
           )}
-          value={endDate}
-          min={startDate || undefined}
+          min={startDate || "1900-01-01"}
+          max={(() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })()}
+          value={endDate || ""}
           onChange={(e) => setEndDate(e.target.value)}
+          onBlur={(e) => {
+            const min = startDate || "1900-01-01";
+            const max = (() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })();
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setEndDate(value);
+            }
+          }}
         />
         {endDateError && (
           <p className="text-red-600 text-sm mt-1">{endDateError}</p>

--- a/src/components/admin/client/filter/ClientDateFilter.tsx
+++ b/src/components/admin/client/filter/ClientDateFilter.tsx
@@ -37,7 +37,17 @@ export default function DateFilter({
             const value = e.target.value;
             setDateFrom(value);
           }}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateFrom(value);
+            }
+          }}
         />
       </div>
       <div className="space-y-2">
@@ -51,7 +61,17 @@ export default function DateFilter({
           )}
           value={to || ""}
           onChange={(e) => setDateTo(e.target.value)}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateTo(value);
+            }
+          }}
         />
         {toDateError && (
           <p className="text-red-600 text-sm mt-1">{toDateError}</p>

--- a/src/components/admin/invoices/filters/InvoiceDateFilter.tsx
+++ b/src/components/admin/invoices/filters/InvoiceDateFilter.tsx
@@ -70,14 +70,23 @@ export default function InvoiceDateFilter({ filters, setFilters }: Props) {
       "w-full border px-3 py-2 rounded",
       startDateError && "border-red-500"
     )}
-    value={startDate}
+    value={startDate || ""}
+    min="1900-01-01"
     max={today}
     onChange={(e) => {
       const value = e.target.value;
       setStartDate(value);
-
       if (endDate && value > endDate) {
         setEndDate("");
+      }
+    }}
+    onBlur={(e) => {
+      const min = "1900-01-01";
+      const max = today;
+      let value = e.target.value;
+      if (value && (value < min || value > max)) {
+        value = value < min ? min : max;
+        setStartDate(value);
       }
     }}
   />
@@ -95,10 +104,19 @@ export default function InvoiceDateFilter({ filters, setFilters }: Props) {
       "w-full border px-3 py-2 rounded",
       endDateError && "border-red-500"
     )}
-    value={endDate}
-    min={startDate || undefined}
+    value={endDate || ""}
+    min={startDate || "1900-01-01"}
     max={today}
     onChange={(e) => setEndDate(e.target.value)}
+    onBlur={(e) => {
+      const min = startDate || "1900-01-01";
+      const max = today;
+      let value = e.target.value;
+      if (value && (value < min || value > max)) {
+        value = value < min ? min : max;
+        setEndDate(value);
+      }
+    }}
   />
   {endDateError && (
     <p className="text-red-600 text-sm mt-1">{endDateError}</p>

--- a/src/components/admin/purchases/filters/PurchaseDateFilter.tsx
+++ b/src/components/admin/purchases/filters/PurchaseDateFilter.tsx
@@ -37,7 +37,17 @@ export default function DateFilter({
             const value = e.target.value;
             setDateFrom(value);
           }}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateFrom(value);
+            }
+          }}
         />
       </div>
       <div className="space-y-2">
@@ -51,7 +61,17 @@ export default function DateFilter({
           )}
           value={to || ""}
           onChange={(e) => setDateTo(e.target.value)}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateTo(value);
+            }
+          }}
         />
         {toDateError && (
           <p className="text-red-600 text-sm mt-1">{toDateError}</p>

--- a/src/components/admin/settings/pets/filter/PetDateFilter.tsx
+++ b/src/components/admin/settings/pets/filter/PetDateFilter.tsx
@@ -31,10 +31,21 @@ export default function PetDateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
+          min="1900-01-01"
+          max={new Date().toISOString().split("T")[0]}
           value={from || ""}
           onChange={(e) => {
             const value = e.target.value;
             setDateFrom(value);
+          }}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateFrom(value);
+            }
           }}
         />
       </div>
@@ -47,8 +58,19 @@ export default function PetDateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
+          min="1900-01-01"
+          max={new Date().toISOString().split("T")[0]}
           value={to || ""}
           onChange={(e) => setDateTo(e.target.value)}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateTo(value);
+            }
+          }}
         />
         {toDateError && (
           <p className="text-red-600 text-sm mt-1">{toDateError}</p>

--- a/src/components/admin/vaccine-registry/filters/VaccineRegistryDateFilter.tsx
+++ b/src/components/admin/vaccine-registry/filters/VaccineRegistryDateFilter.tsx
@@ -110,6 +110,17 @@ export default function VaccineRegistryDateFilter({
                 setToDate("");
               }
             }}
+            min="1900-01-01"
+            max={new Date().toISOString().split("T")[0]}
+            onBlur={(e) => {
+              const min = "1900-01-01";
+              const max = new Date().toISOString().split("T")[0];
+              let value = e.target.value;
+              if (value && (value < min || value > max)) {
+                value = value < min ? min : max;
+                setFromDate(value);
+              }
+            }}
             className="w-full border px-3 py-2 rounded pr-10"
           />
           {fromDate && (
@@ -134,6 +145,16 @@ export default function VaccineRegistryDateFilter({
             value={toDate}
             onChange={(e) => setToDate(e.target.value)}
             min={fromDate || undefined}
+            max={new Date().toISOString().split("T")[0]}
+            onBlur={(e) => {
+              const min = "1900-01-01";
+              const max = new Date().toISOString().split("T")[0];
+              let value = e.target.value;
+              if (value && (value < min || value > max)) {
+                value = value < min ? min : max;
+                setToDate(value);
+              }
+            }}
             className={clsx(
               "w-full border px-3 py-2 rounded pr-10",
               errorMessage && "border-red-500"


### PR DESCRIPTION
Se modificaron los filtros de las siguientes páginas:
- Citas
- Clietnes
- Compras
- Facturas
- Historial de vacunas
- Listado general de mascotas

Se aplicaron las siguientes consideraciones al seleccionar una fecha:
- Fecha desde no debe ser mayor a la fecha hasta
- Corregir el valor de las fechas si estas superan el límite establecido (01-01-1900 a fecha actual) o también (01-01-1900 a fecha actual + 5 años)