### PR TITLE
[490] Funcionalidad en nuevos filtros de fechas

### DIFF
--- a/src/components/admin/appointment/filters/AppointmentDateFilter.tsx
+++ b/src/components/admin/appointment/filters/AppointmentDateFilter.tsx
@@ -70,12 +70,23 @@ export default function AppointmentDateFilter({ filters, setFilters }: Props) {
           className={clsx(
             "w-full border px-3 py-2 rounded",
           )}
-          value={startDate}
+          min="1900-01-01"
+          max={(() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })()}
+          value={startDate || ""}
           onChange={(e) => {
             const value = e.target.value;
             setStartDate(value);
             if (endDate && value > endDate) {
               setEndDate("");
+            }
+          }}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = (() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })();
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setStartDate(value);
             }
           }}
         />
@@ -90,9 +101,19 @@ export default function AppointmentDateFilter({ filters, setFilters }: Props) {
             "w-full border px-3 py-2 rounded",
             endDateError && "border-red-500"
           )}
-          value={endDate}
-          min={startDate || undefined}
+          min={startDate || "1900-01-01"}
+          max={(() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })()}
+          value={endDate || ""}
           onChange={(e) => setEndDate(e.target.value)}
+          onBlur={(e) => {
+            const min = startDate || "1900-01-01";
+            const max = (() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })();
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setEndDate(value);
+            }
+          }}
         />
         {endDateError && (
           <p className="text-red-600 text-sm mt-1">{endDateError}</p>

--- a/src/components/admin/client/ClientList.tsx
+++ b/src/components/admin/client/ClientList.tsx
@@ -54,7 +54,7 @@ export default function ClientList({ token }: ClientListProps) {
             setLoading(true);
 
             try {
-                const results = await fetchUsers(page, query, token);
+                const results = await fetchUsers(page, query, token, from, to);
                 if (!results.data.length && query)
                     toast("info", e("notFound"));
 
@@ -74,12 +74,12 @@ export default function ClientList({ token }: ClientListProps) {
                 setLoading(false);
             }
         },
-        [token]
+        [token, from, to]
     );
 
     useEffect(() => {
         if (token) loadUsers(data.pagination.currentPage);
-    }, [token, data.pagination.currentPage, loadUsers]);
+    }, [token, data.pagination.currentPage, loadUsers, from, to]);
 
     const handleSearch = useCallback(
         (query: string) => {

--- a/src/components/admin/client/filter/ClientDateFilter.tsx
+++ b/src/components/admin/client/filter/ClientDateFilter.tsx
@@ -2,6 +2,8 @@
 
 import { Label } from "@/components/ui/label";
 import clsx from "clsx";
+import { useEffect, useState } from "react";
+import useDebounce from "@/hooks/useDebounce";
 
 interface Props {
   to: string | undefined;
@@ -16,6 +18,21 @@ export default function DateFilter({
   setDateFrom,
   setDateTo,
 }: Props) {
+  const [startDate, setStartDate] = useState(from ?? "");
+  const [endDate, setEndDate] = useState(to ?? "");
+  const debouncedStartDate = useDebounce(startDate, 500);
+  const debouncedEndDate = useDebounce(endDate, 500);
+
+  useEffect(() => {
+    if (from !== debouncedStartDate) setDateFrom(debouncedStartDate || undefined);
+    // Solo actualiza si cambia el valor debounced
+    // eslint-disable-next-line
+  }, [debouncedStartDate]);
+  useEffect(() => {
+    if (to !== debouncedEndDate) setDateTo(debouncedEndDate || undefined);
+    // eslint-disable-next-line
+  }, [debouncedEndDate]);
+
   const isEndDateBeforeStart = from && to && to < from;
   const toDateError = isEndDateBeforeStart
     ? "La fecha hasta no puede ser menor que la fecha desde."
@@ -32,10 +49,10 @@ export default function DateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
-          value={from || ""}
+          value={startDate}
           onChange={(e) => {
             const value = e.target.value;
-            setDateFrom(value);
+            setStartDate(value);
           }}
           min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
@@ -45,7 +62,7 @@ export default function DateFilter({
             let value = e.target.value;
             if (value && (value < min || value > max)) {
               value = value < min ? min : max;
-              setDateFrom(value);
+              setStartDate(value);
             }
           }}
         />
@@ -59,8 +76,8 @@ export default function DateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
-          value={to || ""}
-          onChange={(e) => setDateTo(e.target.value)}
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
           min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
           onBlur={(e) => {
@@ -69,7 +86,7 @@ export default function DateFilter({
             let value = e.target.value;
             if (value && (value < min || value > max)) {
               value = value < min ? min : max;
-              setDateTo(value);
+              setEndDate(value);
             }
           }}
         />

--- a/src/components/admin/client/filter/ClientDateFilter.tsx
+++ b/src/components/admin/client/filter/ClientDateFilter.tsx
@@ -37,7 +37,17 @@ export default function DateFilter({
             const value = e.target.value;
             setDateFrom(value);
           }}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateFrom(value);
+            }
+          }}
         />
       </div>
       <div className="space-y-2">
@@ -51,7 +61,17 @@ export default function DateFilter({
           )}
           value={to || ""}
           onChange={(e) => setDateTo(e.target.value)}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateTo(value);
+            }
+          }}
         />
         {toDateError && (
           <p className="text-red-600 text-sm mt-1">{toDateError}</p>

--- a/src/components/admin/invoices/filters/InvoiceDateFilter.tsx
+++ b/src/components/admin/invoices/filters/InvoiceDateFilter.tsx
@@ -70,14 +70,23 @@ export default function InvoiceDateFilter({ filters, setFilters }: Props) {
       "w-full border px-3 py-2 rounded",
       startDateError && "border-red-500"
     )}
-    value={startDate}
+    value={startDate || ""}
+    min="1900-01-01"
     max={today}
     onChange={(e) => {
       const value = e.target.value;
       setStartDate(value);
-
       if (endDate && value > endDate) {
         setEndDate("");
+      }
+    }}
+    onBlur={(e) => {
+      const min = "1900-01-01";
+      const max = today;
+      let value = e.target.value;
+      if (value && (value < min || value > max)) {
+        value = value < min ? min : max;
+        setStartDate(value);
       }
     }}
   />
@@ -95,10 +104,19 @@ export default function InvoiceDateFilter({ filters, setFilters }: Props) {
       "w-full border px-3 py-2 rounded",
       endDateError && "border-red-500"
     )}
-    value={endDate}
-    min={startDate || undefined}
+    value={endDate || ""}
+    min={startDate || "1900-01-01"}
     max={today}
     onChange={(e) => setEndDate(e.target.value)}
+    onBlur={(e) => {
+      const min = startDate || "1900-01-01";
+      const max = today;
+      let value = e.target.value;
+      if (value && (value < min || value > max)) {
+        value = value < min ? min : max;
+        setEndDate(value);
+      }
+    }}
   />
   {endDateError && (
     <p className="text-red-600 text-sm mt-1">{endDateError}</p>

--- a/src/components/admin/purchases/PurchaseList.tsx
+++ b/src/components/admin/purchases/PurchaseList.tsx
@@ -24,12 +24,14 @@ interface Props {
 
 export default function PurchaseList({ token }: Props) {
   const router = useRouter();
-  const { data, query, setQuery, isLoading, error } = useGetPurchases({
-    token,
-  });
   const [from, setFrom] = useState<string | undefined>();
   const [to, setTo] = useState<string | undefined>();
   const [isGettingReport, setIsGettingReport] = useState(false);
+
+  const { data, query, setQuery, isLoading, error } = useGetPurchases({
+    token,
+    init: { from, to, page: 1 },
+  });
 
   const handleGetPurchaseReport = async () => {
     if (!from || !to) {
@@ -67,8 +69,14 @@ export default function PurchaseList({ token }: Props) {
         <DateFilter
           to={to}
           from={from}
-          setDateTo={setTo}
-          setDateFrom={setFrom}
+          setDateTo={(val) => {
+            setTo(val);
+            setQuery((prev) => ({ ...prev, to: val }));
+          }}
+          setDateFrom={(val) => {
+            setFrom(val);
+            setQuery((prev) => ({ ...prev, from: val }));
+          }}
         />
       </div>
       <div className="flex flex-wrap justify-between items-center gap-4 mb-6">

--- a/src/components/admin/purchases/filters/PurchaseDateFilter.tsx
+++ b/src/components/admin/purchases/filters/PurchaseDateFilter.tsx
@@ -2,6 +2,8 @@
 
 import { Label } from "@/components/ui/label";
 import clsx from "clsx";
+import { useEffect, useState } from "react";
+import useDebounce from "@/hooks/useDebounce";
 
 interface Props {
   to: string | undefined;
@@ -16,6 +18,18 @@ export default function DateFilter({
   setDateFrom,
   setDateTo,
 }: Props) {
+  const [startDate, setStartDate] = useState(from ?? "");
+  const [endDate, setEndDate] = useState(to ?? "");
+  const debouncedStartDate = useDebounce(startDate, 500);
+  const debouncedEndDate = useDebounce(endDate, 500);
+
+  useEffect(() => {
+    if (from !== debouncedStartDate) setDateFrom(debouncedStartDate || undefined);
+  }, [debouncedStartDate]);
+  useEffect(() => {
+    if (to !== debouncedEndDate) setDateTo(debouncedEndDate || undefined);
+  }, [debouncedEndDate]);
+
   const isEndDateBeforeStart = from && to && to < from;
   const toDateError = isEndDateBeforeStart
     ? "La fecha hasta no puede ser menor que la fecha desde."
@@ -32,10 +46,10 @@ export default function DateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
-          value={from || ""}
+          value={startDate}
           onChange={(e) => {
             const value = e.target.value;
-            setDateFrom(value);
+            setStartDate(value);
           }}
           min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
@@ -45,7 +59,7 @@ export default function DateFilter({
             let value = e.target.value;
             if (value && (value < min || value > max)) {
               value = value < min ? min : max;
-              setDateFrom(value);
+              setStartDate(value);
             }
           }}
         />
@@ -59,8 +73,8 @@ export default function DateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
-          value={to || ""}
-          onChange={(e) => setDateTo(e.target.value)}
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
           min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
           onBlur={(e) => {
@@ -69,7 +83,7 @@ export default function DateFilter({
             let value = e.target.value;
             if (value && (value < min || value > max)) {
               value = value < min ? min : max;
-              setDateTo(value);
+              setEndDate(value);
             }
           }}
         />

--- a/src/components/admin/purchases/filters/PurchaseDateFilter.tsx
+++ b/src/components/admin/purchases/filters/PurchaseDateFilter.tsx
@@ -37,7 +37,17 @@ export default function DateFilter({
             const value = e.target.value;
             setDateFrom(value);
           }}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateFrom(value);
+            }
+          }}
         />
       </div>
       <div className="space-y-2">
@@ -51,7 +61,17 @@ export default function DateFilter({
           )}
           value={to || ""}
           onChange={(e) => setDateTo(e.target.value)}
+          min="1900-01-01"
           max={new Date().toISOString().split("T")[0]}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateTo(value);
+            }
+          }}
         />
         {toDateError && (
           <p className="text-red-600 text-sm mt-1">{toDateError}</p>

--- a/src/components/admin/settings/pets/filter/PetDateFilter.tsx
+++ b/src/components/admin/settings/pets/filter/PetDateFilter.tsx
@@ -31,10 +31,21 @@ export default function PetDateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
+          min="1900-01-01"
+          max={new Date().toISOString().split("T")[0]}
           value={from || ""}
           onChange={(e) => {
             const value = e.target.value;
             setDateFrom(value);
+          }}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateFrom(value);
+            }
           }}
         />
       </div>
@@ -47,8 +58,19 @@ export default function PetDateFilter({
             "w-full border px-3 py-2 rounded",
             toDateError && "border-red-500"
           )}
+          min="1900-01-01"
+          max={new Date().toISOString().split("T")[0]}
           value={to || ""}
           onChange={(e) => setDateTo(e.target.value)}
+          onBlur={(e) => {
+            const min = "1900-01-01";
+            const max = new Date().toISOString().split("T")[0];
+            let value = e.target.value;
+            if (value && (value < min || value > max)) {
+              value = value < min ? min : max;
+              setDateTo(value);
+            }
+          }}
         />
         {toDateError && (
           <p className="text-red-600 text-sm mt-1">{toDateError}</p>

--- a/src/components/admin/vaccine-registry/filters/VaccineRegistryDateFilter.tsx
+++ b/src/components/admin/vaccine-registry/filters/VaccineRegistryDateFilter.tsx
@@ -111,10 +111,10 @@ export default function VaccineRegistryDateFilter({
               }
             }}
             min="1900-01-01"
-            max={new Date().toISOString().split("T")[0]}
+            max={(() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })()}
             onBlur={(e) => {
               const min = "1900-01-01";
-              const max = new Date().toISOString().split("T")[0];
+              const max = (() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })();
               let value = e.target.value;
               if (value && (value < min || value > max)) {
                 value = value < min ? min : max;
@@ -144,11 +144,11 @@ export default function VaccineRegistryDateFilter({
             type="date"
             value={toDate}
             onChange={(e) => setToDate(e.target.value)}
-            min={fromDate || undefined}
-            max={new Date().toISOString().split("T")[0]}
+            min={fromDate || "1900-01-01"}
+            max={(() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })()}
             onBlur={(e) => {
               const min = "1900-01-01";
-              const max = new Date().toISOString().split("T")[0];
+              const max = (() => { const d = new Date(); d.setFullYear(d.getFullYear() + 5); return d.toISOString().split('T')[0]; })();
               let value = e.target.value;
               if (value && (value < min || value > max)) {
                 value = value < min ? min : max;

--- a/src/components/admin/vaccine-registry/filters/VaccineRegistryDateFilter.tsx
+++ b/src/components/admin/vaccine-registry/filters/VaccineRegistryDateFilter.tsx
@@ -110,6 +110,17 @@ export default function VaccineRegistryDateFilter({
                 setToDate("");
               }
             }}
+            min="1900-01-01"
+            max={new Date().toISOString().split("T")[0]}
+            onBlur={(e) => {
+              const min = "1900-01-01";
+              const max = new Date().toISOString().split("T")[0];
+              let value = e.target.value;
+              if (value && (value < min || value > max)) {
+                value = value < min ? min : max;
+                setFromDate(value);
+              }
+            }}
             className="w-full border px-3 py-2 rounded pr-10"
           />
           {fromDate && (
@@ -134,6 +145,16 @@ export default function VaccineRegistryDateFilter({
             value={toDate}
             onChange={(e) => setToDate(e.target.value)}
             min={fromDate || undefined}
+            max={new Date().toISOString().split("T")[0]}
+            onBlur={(e) => {
+              const min = "1900-01-01";
+              const max = new Date().toISOString().split("T")[0];
+              let value = e.target.value;
+              if (value && (value < min || value > max)) {
+                value = value < min ? min : max;
+                setToDate(value);
+              }
+            }}
             className={clsx(
               "w-full border px-3 py-2 rounded pr-10",
               errorMessage && "border-red-500"

--- a/src/lib/client/getUsers.ts
+++ b/src/lib/client/getUsers.ts
@@ -1,10 +1,12 @@
 import { CLIENT_API } from "../urls";
 
-export const fetchUsers = async (page: number, query: string, token: string | null) => {
+export const fetchUsers = async (page: number, query: string, token: string | null, from?: string, to?: string) => {
     try {
-        const url = query
+        let url = query
             ? `${CLIENT_API}?page=${page}&query=${encodeURIComponent(query)}`
             : `${CLIENT_API}?page=${page}&size=7`;
+        if (from) url += `&from=${encodeURIComponent(from)}`;
+        if (to) url += `&to=${encodeURIComponent(to)}`;
 
         const response = await fetch(url, {
             headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
Se trajeron cambios realizados en la rama de 495, por lo que hay más cambios de los que en realidad son, los cambios realizados son los siguientes:

Se añadieron funcionalidad a los filtros de fechas de las páginas: Clientes y Compras, que utilizan el endpoint con atributos "from" y "to" para especificar la fecha. También se modificó el historial de vacunas para que bloquea las fechas 5 años en el futuro.

Debido a limitaciones del endpoint no se permiten búsquedas directas en fechas de compras realizadas por lo que puede haber un comportamiento raro, ej: buscas desde 20/05/2025 hasta fecha actual, te siguen mostrando fechas del 13/05/2025.