### PR TITLE
Task 479 mejorar buscador producto en registrar movimiento

### DIFF
--- a/src/components/admin/movements/register/MovementForm.tsx
+++ b/src/components/admin/movements/register/MovementForm.tsx
@@ -40,8 +40,9 @@ export default function MovementForm({ token }: { token: string }) {
     submitMovement,
   } = useRegisterMovement(token);
 
-  const { stocks } = useInitialData(token);
-  const selectedStockId = watch("originStockId") ?? null;
+const { stocks } = useInitialData(token);
+const selectedStockId = watch("originStockId") ?? null;
+const movementType = watch("type"); // Obtener el tipo de movimiento
 
 const {
   searchProducts,
@@ -52,7 +53,7 @@ const {
   setProductQuantity,
   resetSearch,
   isLoading: isLoadingProduct,
-} = useProductStock(token, selectedStockId);
+} = useProductStock(token, selectedStockId, movementType); 
 
 
   const {
@@ -66,6 +67,7 @@ const {
   const router = useRouter();
   const details = watch("details") || [];
   const [selectedEmployee, setSelectedEmployee] = useState<EmployeeData | null>(null);
+  
 
   const m = useTranslations("MovementForm");
   const b = useTranslations("Button");

--- a/src/hooks/movements/useRegisterMovements.ts
+++ b/src/hooks/movements/useRegisterMovements.ts
@@ -99,10 +99,18 @@ export const useRegisterMovement = (token: string) => {
       reset();
       return true;
     } catch (error: unknown) {
-      toast(
-        "error",
-        error instanceof Error ? error.message : "Error al registrar movimiento"
-      );
+      const errorMessage =
+        error instanceof Error ? error.message : "Error al registrar movimiento";
+
+      if (
+        typeof errorMessage === "string" &&
+        errorMessage.includes("Stock insuficiente")
+      ) {
+        toast("error", "No hay suficiente cantidad en el depósito.");
+      } else {
+        toast("error", errorMessage);
+      }
+
       return false;
     }
   };

--- a/src/hooks/purchases/useProductSearch.tsx
+++ b/src/hooks/purchases/useProductSearch.tsx
@@ -7,7 +7,7 @@ interface ExtendedProductQueryParams extends ProductQueryParams {
   name?: string;
 }
 
-export const useProductSearch = (token: string, excludeServices: boolean = true) => {
+export const useProductSearch = (token: string) => {
   const [searchProducts, setSearchProducts] = useState<Product[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [quantities, setQuantities] = useState<{ [id: string]: number }>({});
@@ -25,18 +25,12 @@ export const useProductSearch = (token: string, excludeServices: boolean = true)
           name: query,
         };
         const res = await getProducts(params, token);
-        let productList = res.data
-          ? Array.isArray(res.data)
-            ? res.data
-            : []
-          : [];
-        
-        // Filtrar servicios si se especifica
-        if (excludeServices) {
-          productList = productList.filter((p) => p.category !== "SERVICE");
-        }
-        
-        setSearchProducts(productList);
+        const productList = Array.isArray(res.data) ? res.data : [];
+
+        //excluir servicios
+        const filtered = productList.filter((p) => p.category !== "SERVICE");
+
+        setSearchProducts(filtered);
       } catch (error) {
         toast(
           "error",
@@ -49,7 +43,7 @@ export const useProductSearch = (token: string, excludeServices: boolean = true)
         setIsLoading(false);
       }
     },
-    [token, excludeServices]
+    [token]
   );
 
   useEffect(() => {

--- a/src/hooks/purchases/useProductSearch.tsx
+++ b/src/hooks/purchases/useProductSearch.tsx
@@ -7,7 +7,7 @@ interface ExtendedProductQueryParams extends ProductQueryParams {
   name?: string;
 }
 
-export const useProductSearch = (token: string) => {
+export const useProductSearch = (token: string, excludeServices: boolean = true) => {
   const [searchProducts, setSearchProducts] = useState<Product[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [quantities, setQuantities] = useState<{ [id: string]: number }>({});
@@ -25,11 +25,17 @@ export const useProductSearch = (token: string) => {
           name: query,
         };
         const res = await getProducts(params, token);
-        const productList = res.data
+        let productList = res.data
           ? Array.isArray(res.data)
             ? res.data
             : []
           : [];
+        
+        // Filtrar servicios si se especifica
+        if (excludeServices) {
+          productList = productList.filter((p) => p.category !== "SERVICE");
+        }
+        
         setSearchProducts(productList);
       } catch (error) {
         toast(
@@ -43,7 +49,7 @@ export const useProductSearch = (token: string) => {
         setIsLoading(false);
       }
     },
-    [token]
+    [token, excludeServices]
   );
 
   useEffect(() => {

--- a/src/hooks/purchases/useProductStock.tsx
+++ b/src/hooks/purchases/useProductStock.tsx
@@ -2,18 +2,27 @@ import { Product } from "@/lib/products/IProducts";
 import { getStockProducts } from "@/lib/stock/getStockProduct";
 import { toast } from "@/lib/toast";
 import { useCallback, useEffect, useState } from "react";
-import useDebounce from "../useDebounce"; 
+import useDebounce from "../useDebounce";
+import { useProductSearch } from "./useProductSearch"; 
 
-export const useProductStock = (token: string, stockId: number | null) => {
+export const useProductStock = (
+  token: string, 
+  stockId: number | null,
+  movementType?: string
+) => {
+  // Para movimientos INBOUND, usa el hook de búsqueda general
+  const productSearchHook = useProductSearch(token);
+  
+  // Para movimientos que requieren stock específico
   const [searchProducts, setSearchProducts] = useState<Product[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [quantities, setQuantities] = useState<{ [id: string]: number }>({});
   const [isLoading, setIsLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
 
-  const debouncedQuery = useDebounce(searchQuery, 1000); 
+  const debouncedQuery = useDebounce(searchQuery, 1000);
 
-  const fetchProducts = useCallback(
+  const fetchStockProducts = useCallback(
     async (query: string) => {
       if (!stockId) return;
       setIsLoading(true);
@@ -22,7 +31,7 @@ export const useProductStock = (token: string, stockId: number | null) => {
         const stockData = await getStockProducts(stockId, query, token);
         const productList = stockData
           .map((item) => item.product)
-          .filter((p) => p.category !== "SERVICE"); // Evitar servicios
+          .filter((p) => p.category !== "SERVICE");
         setSearchProducts(productList);
       } catch (error) {
         toast(
@@ -40,42 +49,69 @@ export const useProductStock = (token: string, stockId: number | null) => {
   );
 
   useEffect(() => {
-    if (debouncedQuery) {
-      fetchProducts(debouncedQuery);
-    } else {
+    // Solo usa fetchStockProducts para OUTBOUND y TRANSFER
+    if (movementType !== "INBOUND" && debouncedQuery) {
+      fetchStockProducts(debouncedQuery);
+    } else if (movementType !== "INBOUND") {
       setSearchProducts([]);
       setHasSearched(false);
     }
-  }, [debouncedQuery, fetchProducts]);
+  }, [debouncedQuery, fetchStockProducts, movementType]);
 
   const handleSearchProduct = (query: string) => {
-    setSearchQuery(query);
+    if (movementType === "INBOUND") {
+      // Para INBOUND, usa el hook de búsqueda general
+      productSearchHook.handleSearchProduct(query);
+    } else {
+      // Para OUTBOUND y TRANSFER, usa búsqueda por stock
+      setSearchQuery(query);
+    }
   };
 
   const setProductQuantity = (productId: string, value: number) => {
-    setQuantities((prev) => ({
-      ...prev,
-      [productId]: value,
-    }));
+    if (movementType === "INBOUND") {
+      productSearchHook.setProductQuantity(productId, value);
+    } else {
+      setQuantities((prev) => ({
+        ...prev,
+        [productId]: value,
+      }));
+    }
   };
 
   const getProductQuantity = (productId: string) => {
+    if (movementType === "INBOUND") {
+      return productSearchHook.getProductQuantity(productId);
+    }
     return quantities[productId] ?? 1;
   };
 
   const resetSearch = () => {
-    setSearchQuery("");
-    setQuantities({});
+    if (movementType === "INBOUND") {
+      productSearchHook.resetSearch();
+    } else {
+      setSearchQuery("");
+      setQuantities({});
+    }
   };
 
+  // Retorna los datos apropiados según el tipo de movimiento
   return {
-    searchProducts,
-    searchQuery,
-    hasSearched,
+    searchProducts: movementType === "INBOUND" 
+      ? productSearchHook.searchProducts 
+      : searchProducts,
+    searchQuery: movementType === "INBOUND" 
+      ? productSearchHook.searchQuery 
+      : searchQuery,
+    hasSearched: movementType === "INBOUND" 
+      ? productSearchHook.hasSearched 
+      : hasSearched,
     handleSearchProduct,
     setProductQuantity,
     getProductQuantity,
     resetSearch,
-    isLoading,
+    isLoading: movementType === "INBOUND" 
+      ? productSearchHook.isLoading 
+      : isLoading,
   };
 };


### PR DESCRIPTION
Se utiliza el hook useProductSearch para buscar productos.

Se modificó useProductSearch para excluir servicios en los resultados, dado que los servicios no aplican para movimientos de productos físicos.

Se actualizó el mensaje de error que aparece al intentar transferir productos con cantidad insuficiente.