### PR TITLE
Task 488 agregar cantidad maxima en input y textarea

### DIFF
--- a/src/components/admin/appointment/AppointmentList.tsx
+++ b/src/components/admin/appointment/AppointmentList.tsx
@@ -28,6 +28,7 @@ import { downloadFromBlob, normalizeText } from "@/lib/utils";
 import ExportButton from "@/components/global/ExportButton";
 import { getAppointmentReport } from "@/lib/appointment/getAppointmentReport";
 import { unknown } from "zod";
+import { Textarea } from "@/components/ui/textarea";
 
 interface AppointmentListProps {
     token: string;
@@ -302,7 +303,7 @@ const AppointmentList = ({ token }: AppointmentListProps) => {
                     title={a("titleCancel")}
                     size="md"
                 >
-                    <textarea
+                    <Textarea
                         className="w-full h-32 p-2 border border-gray-300 rounded"
                         placeholder={ph("reason")}
                         value={cancelDescription}

--- a/src/components/admin/appointment/AppointmentListByClient.tsx
+++ b/src/components/admin/appointment/AppointmentListByClient.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/appointment/service";
 import { ConfirmationModal } from "@/components/global/Confirmation-modal";
 import AppointmentListSkeleton from "./Skeleton/AppointmentListSkeleton";
+import { Textarea } from "@/components/ui/textarea";
 
 interface ClientAppointmentListProps {
   token: string;
@@ -183,7 +184,7 @@ const ClientAppointmentList = ({
           title="Motivo de cancelación"
           size="md"
         >
-          <textarea
+          <Textarea
             className="w-full h-32 p-2 border border-gray-300 rounded"
             placeholder="Escribe una razón para cancelar la cita"
             value={cancelDescription}

--- a/src/components/admin/appointment/AppointmentListByEmployee.tsx
+++ b/src/components/admin/appointment/AppointmentListByEmployee.tsx
@@ -21,6 +21,7 @@ import {
 import { Modal } from "@/components/global/Modal";
 import { Button } from "@/components/ui/button";
 import AppointmentListSkeleton from "./Skeleton/AppointmentListSkeleton";
+import { Textarea } from "@/components/ui/textarea";
 
 interface AppointmentListProps {
     token: string;
@@ -259,7 +260,7 @@ const AppointmentList = ({ token, employeeRuc }: AppointmentListProps) => {
                     title="Motivo de cancelación"
                     size="md"
                 >
-                    <textarea
+                    <Textarea
                         className="w-full h-32 p-2 border border-gray-300 rounded"
                         placeholder="Escribe una razón para cancelar la cita"
                         value={cancelDescription}

--- a/src/components/admin/appointment/register/AppointmentForm.tsx
+++ b/src/components/admin/appointment/register/AppointmentForm.tsx
@@ -23,6 +23,7 @@ import EmployeeSelected from "./EmployeeSelected";
 import { AvailabilityPicker } from "./AvailabilityPicker";
 import { Trash } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Textarea } from "@/components/ui/textarea";
 
 type AppointmentFormProps = {
   token: string;
@@ -210,7 +211,7 @@ export const AppointmentForm = ({ token }: AppointmentFormProps) => {
         <label className="block text-sm font-medium text-gray-700">
           {a("details")}
         </label>
-        <textarea
+        <Textarea
           {...register("details")}
           className="w-full border border-gray-300 rounded-md p-2"
           rows={4}

--- a/src/components/admin/pet/VisitList.tsx
+++ b/src/components/admin/pet/VisitList.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { useTranslations } from "next-intl";
+import { Textarea } from "@/components/ui/textarea";
 
 interface VisitListProps {
   token: string;
@@ -177,7 +178,7 @@ export default function VisitList({ token, petId }: VisitListProps) {
           title={m("motivo")}
           size="md"
         >
-          <textarea
+          <Textarea
             className="w-full h-32 p-2 border border-gray-300 rounded"
             placeholder={m("reason")}
             value={cancelDescription}

--- a/src/components/admin/product/ProductDetail.tsx
+++ b/src/components/admin/product/ProductDetail.tsx
@@ -89,7 +89,7 @@ export default function ProductDetail({ token }: ProductDetailProps) {
 
   return (
     <div className="max-w-5xl mx-auto p-6">
-      <div className="mb-6 mt-6">
+      <div className="mb-3">
         <Button
           variant="outline"
           onClick={() => router.push('/dashboard/products')}

--- a/src/components/admin/product/ProductRegister.tsx
+++ b/src/components/admin/product/ProductRegister.tsx
@@ -23,6 +23,7 @@ import {
 import { useInitialData } from "@/hooks/purchases/useProviderStock";
 import { X } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Textarea } from "@/components/ui/textarea";
 
 const MAX_FILE_SIZE = 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -176,7 +177,7 @@ export default function ProductRegisterForm({
           </div>
           <div>
             <Label>{p("description")}</Label>
-            <textarea
+            <Textarea
               {...register("description")}
               placeholder={ph("description")}
               className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm placeholder:text-sm placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-black"

--- a/src/components/admin/product/ProductUpdate.tsx
+++ b/src/components/admin/product/ProductUpdate.tsx
@@ -27,6 +27,7 @@ import { useInitialData } from "@/hooks/purchases/useProviderStock";
 
 import { X } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Textarea } from "@/components/ui/textarea";
 
 const MAX_FILE_SIZE = 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -235,7 +236,7 @@ export default function ProductUpdateForm({ token }: ProductUpdateFormProps) {
             </div>
             <div>
               <Label>{p("description")}</Label>
-              <textarea
+              <Textarea
                 {...register("description")}
                 placeholder={ph("description")}
                 className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-black placeholder:text-sm placeholder:text-gray-500"

--- a/src/components/appointment/register/AppointmentForm.tsx
+++ b/src/components/appointment/register/AppointmentForm.tsx
@@ -38,6 +38,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useTranslations } from "next-intl"
+import { Textarea } from "@/components/ui/textarea";
 
 type AppointmentFormProps = {
   token: string;
@@ -312,7 +313,7 @@ export const AppointmentForm = ({
                 <h3 className="font-medium">{a("details")}</h3>
               </div>
               <div>
-                <textarea
+                <Textarea
                   {...register("details")}
                   className="w-full border border-myPurple-tertiary rounded-md p-3 focus:ring-myPurple-primary focus:border-myPurple-primary transition-all duration-200"
                   rows={4}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
     return (
       <input
         type={type}
-        maxLength={20}
+        maxLength={50}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,6 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
     return (
       <input
         type={type}
+        maxLength={20}
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -12,7 +12,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
     return (
       <textarea
-        maxLength={40}
+        maxLength={50}
         className={cn(
           "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -12,6 +12,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
     return (
       <textarea
+        maxLength={40}
         className={cn(
           "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className


### PR DESCRIPTION
Se agregó maxLength={50} en los componentes reutilizables Input y Textarea.
Se reemplazaron los <textarea> usados directamente por el componente Textarea para unificar el límite de caracteres.

**Se estableció un máximo de 50 caracteres porque los inputs suelen requerir más espacio (por ejemplo, para correos electrónicos largos), mientras que los textareas, orientados a descripciones o comentarios, necesitan permitir al menos casi toda una línea**
**Si se requiere una longitud distinta, avisar antes de enviar a dev para ajustar según corresponda.**